### PR TITLE
Adds Typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,20 @@
+import { DialogProps } from "@material-ui/core/Dialog";
+import React from "react";
+
+interface WithConfirmOptions {
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  confirmationText?: React.ReactNode;
+  cancellationText?: React.ReactNode;
+  dialogProps?: DialogProps;
+  onClose?(): void;
+  onCancel?(): void;
+}
+export interface WithConfirmProps {
+  confirm(onConfirm: () => void, options: WithConfirmOptions): () => void;
+}
+declare const withConfirm: <T extends WithConfirmProps = WithConfirmProps>(
+  WrappedComponent: React.ComponentType<T>,
+) => React.ComponentType<Omit<T, "confirm">>;
+ 
+export default withConfirm;


### PR DESCRIPTION
Adds index.d.ts with Typescript typings for the library.

`index.d.ts` is the default definitions locations. If the file is in the project root and is named `index.d.ts` then there is no need to modify package.json.