### PR TITLE
chore(pckgs): bump react/react-dom in peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
     "rollup-plugin-copy": "^3.3.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0",
+    "react": "^16.8.0 || ^17.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0",
     "@material-ui/core": ">= 3.0.0"
   },
   "dependencies": {}


### PR DESCRIPTION
Hi! Thx for very useful package!

I propose bump react & react-dom versions for suppress warning on working with react17:

```
warning " > material-ui-confirm@2.1.1" has incorrect peer dependency "react@^16.8.0".
warning " > material-ui-confirm@2.1.1" has incorrect peer dependency "react-dom@^16.8.0".
```