### PR TITLE
Added ConfirmDialogCancellationError

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ export default Item;
 
 This component is required in order to render a dialog in the component tree.
 
-##### Props:
+##### Props
 
 | Name | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |
@@ -82,7 +82,7 @@ This hook returns the `confirm` function.
 This function opens a confirmation dialog and returns a promise
 representing the user choice (resolved on confirmation and rejected on cancellation).
 
-##### Options:
+##### Options
 
 | Name | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |
@@ -93,6 +93,7 @@ representing the user choice (resolved on confirmation and rejected on cancellat
 | **`dialogProps`** | `object` | `{}` | Material-UI [Dialog](https://material-ui.com/api/dialog/#props) props. |
 | **`confirmationButtonProps`** | `object` | `{}` | Material-UI [Button](https://material-ui.com/api/button/#props) props for the confirmation button. |
 | **`cancellationButtonProps`** | `object` | `{}` | Material-UI [Button](https://material-ui.com/api/dialog/#props) props for the cancellation button. |
+| **`rejectionPayload`** | `(() => any) \| any` | `ConfirmDialogCancellationError` | Custom rejection payload |
 
 ## Useful notes
 

--- a/src/ConfirmDialogCancellationError.js
+++ b/src/ConfirmDialogCancellationError.js
@@ -1,0 +1,7 @@
+export default class ConfirmDialogCancellationError extends Error { }
+
+ConfirmDialogCancellationError.prototype.isConfirmDialogCancellationError = true;
+
+export const isConfirmDialogCancellationError = (error) => {
+    return Boolean(error.isConfirmDialogCancellationError)
+}

--- a/src/ConfirmProvider.js
+++ b/src/ConfirmProvider.js
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, Fragment } from 'react';
 import ConfirmContext from './ConfirmContext';
 import ConfirmationDialog from './ConfirmationDialog';
+import ConfirmDialogCancellationError from './ConfirmDialogCancellationError';
 
 const DEFAULT_OPTIONS = {
   title: 'Are you sure?',
@@ -10,6 +11,7 @@ const DEFAULT_OPTIONS = {
   dialogProps: {},
   confirmationButtonProps: {},
   cancellationButtonProps: {},
+  rejectionPayload: new ConfirmDialogCancellationError(),
 };
 
 const buildOptions = (defaultOptions, options) => {
@@ -26,6 +28,8 @@ const buildOptions = (defaultOptions, options) => {
     ...(options.cancellationButtonProps || {}),
   };
 
+  const rejectionPayload = options.rejectionPayload || defaultOptions.rejectionPayload || DEFAULT_OPTIONS.rejectionPayload;
+
   return {
     ...DEFAULT_OPTIONS,
     ...defaultOptions,
@@ -33,6 +37,7 @@ const buildOptions = (defaultOptions, options) => {
     dialogProps,
     confirmationButtonProps,
     cancellationButtonProps,
+    rejectionPayload,
   }
 };
 
@@ -53,7 +58,10 @@ const ConfirmProvider = ({ children, defaultOptions = {} }) => {
   }, []);
 
   const handleCancel = useCallback(() => {
-    reject();
+    const rejectionPayload = typeof options.rejectionPayload === 'function'
+      ? options.rejectionPayload()
+      : options.rejectionPayload;
+    reject(rejectionPayload);
     handleClose();
   }, [reject, handleClose]);
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { DialogProps } from '@material-ui/core/Dialog';
 import { ButtonProps } from '@material-ui/core/Button';
+import ConfirmDialogCancellationError  from './ConfirmDialogCancellationError';
 
 export interface ConfirmOptions {
   title?: React.ReactNode;
@@ -10,6 +11,7 @@ export interface ConfirmOptions {
   dialogProps?: DialogProps;
   confirmationButtonProps?: ButtonProps;
   cancellationButtonProps?: ButtonProps;
+  rejectionPayload?: (() => unknown) | unknown;
 }
 
 export interface ConfirmProviderProps {
@@ -19,3 +21,5 @@ export interface ConfirmProviderProps {
 export const ConfirmProvider: React.ComponentType<ConfirmProviderProps>;
 
 export const useConfirm: () => (options?: ConfirmOptions) => Promise<void>;
+
+export const isConfirmDialogCancellationError: (error: unknown) => error is ConfirmDialogCancellationError;

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,3 @@
 export { default as ConfirmProvider } from './ConfirmProvider';
 export { default as useConfirm } from './useConfirm';
+export { default as ConfirmDialogCancellationError, isConfirmDialogCancellationError } from './ConfirmDialogCancellationError';

--- a/test/ConfirmDialogCancellationError.test.js
+++ b/test/ConfirmDialogCancellationError.test.js
@@ -1,0 +1,15 @@
+import { ConfirmDialogCancellationError, isConfirmDialogCancellationError } from "../src";
+
+describe('ConfirmDialogCancellationError', () => {
+    describe('isConfirmDialogCancellationError', () => {
+        test('should return true when error is instance of ConfirmDialogCancellationError', () => {
+            const error = new ConfirmDialogCancellationError();
+            expect(isConfirmDialogCancellationError(error)).toBe(true);
+        });
+
+        test('should return false when error is *not* instance of ConfirmDialogCancellationError', () => {
+            const error = new Error();
+            expect(isConfirmDialogCancellationError(error)).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
Currently, the confirm dialog rejects with `undefined`. Added behaviour to reject with a `ConfirmDialogCancellationError` or a configurable user-defined error. This would be a breaking change for those that were expecting the dialog to reject with `undefined`.