### PR TITLE
Fix multiple clicks on confirm or cancel button (#34)

### DIFF
--- a/src/ConfirmProvider.js
+++ b/src/ConfirmProvider.js
@@ -54,13 +54,17 @@ const ConfirmProvider = ({ children, defaultOptions = {} }) => {
   }, []);
 
   const handleCancel = useCallback(() => {
-    reject();
-    handleClose();
+    if (reject) {
+      reject();
+      handleClose();
+    }
   }, [reject, handleClose]);
 
   const handleConfirm = useCallback(() => {
-    resolve();
-    handleClose();
+    if (resolve) {
+      resolve();
+      handleClose();
+    }
   }, [resolve, handleClose]);
 
   return (


### PR DESCRIPTION
Fixes #34

Hi @jonatanklosko 

The issue was caused because the current code is maintaining related state variables in different hook variables. This is not a recommended approach because it can cause incorrect/unreliable state updates like in this case.

So, I did not re-wire the logic (I did not merge all the states into a single react state variable) but instead introduced a (new) `state` variable (literally, the state of Dialog component - `idle`, `open`, `submitting`).

This helps in catching the incorrect flows and we can now correctly map the `open` state of the MUI Dialog component now.