### PR TITLE
added configurable props for DialogTitle and DialogContent for accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ export default Item;
 
 This component is required in order to render a dialog in the component tree.
 
-##### Props:
+##### Props
 
 | Name | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |
@@ -83,7 +83,7 @@ This hook returns the `confirm` function.
 This function opens a confirmation dialog and returns a promise
 representing the user choice (resolved on confirmation and rejected on cancellation).
 
-##### Options:
+##### Options
 
 | Name | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |
@@ -95,6 +95,8 @@ representing the user choice (resolved on confirmation and rejected on cancellat
 | **`dialogProps`** | `object` | `{}` | Material-UI [Dialog](https://material-ui.com/api/dialog/#props) props. |
 | **`confirmationButtonProps`** | `object` | `{}` | Material-UI [Button](https://material-ui.com/api/button/#props) props for the confirmation button. |
 | **`cancellationButtonProps`** | `object` | `{}` | Material-UI [Button](https://material-ui.com/api/dialog/#props) props for the cancellation button. |
+| **`titleProps`** | `object` | `{}` | Material-UI [DialogTitle](https://mui.com/api/dialog-title/#props) props for the dialog title. |
+| **`contentProps`** | `object` | `{}` | Material-UI [DialogContent](https://mui.com/api/dialog-content/#props) props for the dialog content. |
 
 ## Useful notes
 

--- a/src/ConfirmProvider.js
+++ b/src/ConfirmProvider.js
@@ -11,6 +11,8 @@ const DEFAULT_OPTIONS = {
   dialogProps: {},
   confirmationButtonProps: {},
   cancellationButtonProps: {},
+  titleProps: {},
+  contentProps: {},
 };
 
 const buildOptions = (defaultOptions, options) => {
@@ -26,6 +28,14 @@ const buildOptions = (defaultOptions, options) => {
     ...(defaultOptions.cancellationButtonProps || DEFAULT_OPTIONS.cancellationButtonProps),
     ...(options.cancellationButtonProps || {}),
   };
+  const titleProps = {
+    ...(defaultOptions.titleProps || DEFAULT_OPTIONS.titleProps),
+    ...(options.titleProps || {}),
+  };
+  const contentProps = {
+    ...(defaultOptions.contentProps || DEFAULT_OPTIONS.contentProps),
+    ...(options.contentProps || {}),
+  };
 
   return {
     ...DEFAULT_OPTIONS,
@@ -34,6 +44,8 @@ const buildOptions = (defaultOptions, options) => {
     dialogProps,
     confirmationButtonProps,
     cancellationButtonProps,
+    titleProps,
+    contentProps,
   }
 };
 

--- a/src/ConfirmationDialog.js
+++ b/src/ConfirmationDialog.js
@@ -16,20 +16,22 @@ const ConfirmationDialog = ({ open, options, onCancel, onConfirm, onClose }) => 
     dialogProps,
     confirmationButtonProps,
     cancellationButtonProps,
+    titleProps,
+    contentProps,
   } = options;
 
   return (
     <Dialog fullWidth {...dialogProps} open={open} onClose={onClose}>
       {title && (
-        <DialogTitle>{title}</DialogTitle>
+        <DialogTitle {...titleProps}>{title}</DialogTitle>
       )}
       {content ? (
-        <DialogContent>
+        <DialogContent {...contentProps}>
           {content}
         </DialogContent>
       ) : (
         description && (
-          <DialogContent>
+          <DialogContent {...contentProps}>
             <DialogContentText>{description}</DialogContentText>
           </DialogContent>
         )

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,11 +1,15 @@
 import * as React from 'react';
 import { DialogProps } from '@material-ui/core/Dialog';
+import { DialogTitleProps } from '@material-ui/core/DialogTitle';
+import { DialogContentProps } from '@material-ui/core/DialogContent';
 import { ButtonProps } from '@material-ui/core/Button';
 
 export interface ConfirmOptions {
   title?: React.ReactNode;
+  titleProps?: DialogTitleProps;
   description?: React.ReactNode;
   content?: React.ReactNode | null;
+  contentProps?: DialogContentProps;
   confirmationText?: React.ReactNode;
   cancellationText?: React.ReactNode;
   dialogProps?: Omit<DialogProps, "open">;


### PR DESCRIPTION
Added configurable props for `DialogTitle` and `DialogContent`. The main driver of this was aria props such as `aria-labelledby` and `aria-describedby`.