### PR TITLE
Add support to disable cancel button

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ representing the user choice (resolved on confirmation and rejected on cancellat
 ##### Options
 
 | Name                                    | Type        | Default           | Description                                                                                                                                                                                                                            |
-| --------------------------------------- | ----------- | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|-----------------------------------------| ----------- | ----------------- |----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **`title`**                             | `ReactNode` | `'Are you sure?'` | Dialog title.                                                                                                                                                                                                                          |
 | **`description`**                       | `ReactNode` | `''`              | Dialog content, automatically wrapped in `DialogContentText`.                                                                                                                                                                          |
 | **`content`**                           | `ReactNode` | `null`            | Dialog content, same as `description` but not wrapped in `DialogContentText`. Supersedes `description` if present.                                                                                                                     |
@@ -97,6 +97,8 @@ representing the user choice (resolved on confirmation and rejected on cancellat
 | **`allowClose`**                        | `boolean`   | `true`            | Whether natural close (escape or backdrop click) should close the dialog. When set to `false` force the user to either cancel or confirm explicitly.                                                                                   |
 | **`confirmationKeyword`**               | `string`    | `undefined`       | If provided the confirmation button will be disabled by default and an additional textfield will be rendered. The confirmation button will only be enabled when the contents of the textfield match the value of `confirmationKeyword` |
 | **`confirmationKeywordTextFieldProps`** | `object`    | `{}`              | Material-UI [TextField](https://mui.com/material-ui/api/text-field/) props for the confirmation keyword textfield.                                                                                                                     |
+| **`hideCancelButton`**                  | `boolean`   | `false`           | Whether to hide the cancel button.                                                                                                                                                                                                     |
+
 
 ## Useful notes
 

--- a/src/ConfirmProvider.js
+++ b/src/ConfirmProvider.js
@@ -16,6 +16,7 @@ const DEFAULT_OPTIONS = {
   contentProps: {},
   allowClose: true,
   confirmationKeywordTextFieldProps: {},
+  hideCancelButton: false,
 };
 
 const buildOptions = (defaultOptions, options) => {

--- a/src/ConfirmationDialog.js
+++ b/src/ConfirmationDialog.js
@@ -29,7 +29,7 @@ const ConfirmationDialog = ({
     allowClose,
     confirmationKeyword,
     confirmationKeywordTextFieldProps,
-    disableCancelButton,
+    hideCancelButton,
   } = options;
 
   const [confirmationKeywordValue, setConfirmationKeywordValue] =
@@ -75,7 +75,7 @@ const ConfirmationDialog = ({
         )
       )}
       <DialogActions {...dialogActionsProps}>
-        {!disableCancelButton && (
+        {!hideCancelButton && (
           <Button {...cancellationButtonProps} onClick={onCancel}>
             {cancellationText}
           </Button>

--- a/src/ConfirmationDialog.js
+++ b/src/ConfirmationDialog.js
@@ -29,6 +29,7 @@ const ConfirmationDialog = ({
     allowClose,
     confirmationKeyword,
     confirmationKeywordTextFieldProps,
+    disableCancelButton,
   } = options;
 
   const [confirmationKeywordValue, setConfirmationKeywordValue] =
@@ -74,9 +75,11 @@ const ConfirmationDialog = ({
         )
       )}
       <DialogActions {...dialogActionsProps}>
-        <Button {...cancellationButtonProps} onClick={onCancel}>
-          {cancellationText}
-        </Button>
+        {!disableCancelButton && (
+          <Button {...cancellationButtonProps} onClick={onCancel}>
+            {cancellationText}
+          </Button>
+        )}
         <Button
           color="primary"
           disabled={confirmationButtonDisabled}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -21,7 +21,7 @@ export interface ConfirmOptions {
   allowClose?: boolean;
   confirmationKeyword?: string;
   confirmationKeywordTextFieldProps?: TextFieldProps;
-  disableCancelButton?: boolean;
+  hideCancelButton?: boolean;
 }
 
 export interface ConfirmProviderProps {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -21,6 +21,7 @@ export interface ConfirmOptions {
   allowClose?: boolean;
   confirmationKeyword?: string;
   confirmationKeywordTextFieldProps?: TextFieldProps;
+  disableCancelButton?: boolean;
 }
 
 export interface ConfirmProviderProps {

--- a/test/useConfirm.test.js
+++ b/test/useConfirm.test.js
@@ -3,7 +3,6 @@ import {
   render,
   fireEvent,
   waitForElementToBeRemoved,
-  getByPlaceholderText,
 } from "@testing-library/react";
 
 import { ConfirmProvider, useConfirm } from "../src/index";
@@ -194,5 +193,39 @@ describe("useConfirm", () => {
     const textfield = queryByPlaceholderText("Custom placeholder");
 
     expect(textfield).toBeTruthy();
+  });
+
+  describe("disable cancel button", () => {
+    test("renders cancel button when disableCancelButton is false", () => {
+      const { getByText } = render(
+        <TestComponent
+          confirmOptions={{
+            disableCancelButton: false,
+          }}
+        />
+      );
+
+      fireEvent.click(getByText("Delete"));
+
+      const cancelButton = getByText("Cancel");
+
+      expect(cancelButton).toBeTruthy();
+    });
+
+    test("does not render cancel button when disableCancelButton is true", () => {
+      const { getByText, queryByText } = render(
+        <TestComponent
+          confirmOptions={{
+            disableCancelButton: true,
+          }}
+        />
+      );
+
+      fireEvent.click(getByText("Delete"));
+
+      const cancelButton = queryByText("Cancel");
+
+      expect(cancelButton).toBeFalsy();
+    });
   });
 });

--- a/test/useConfirm.test.js
+++ b/test/useConfirm.test.js
@@ -195,12 +195,12 @@ describe("useConfirm", () => {
     expect(textfield).toBeTruthy();
   });
 
-  describe("disable cancel button", () => {
-    test("renders cancel button when disableCancelButton is false", () => {
+  describe("hide cancel button", () => {
+    test("renders cancel button when hideCancelButton is false", () => {
       const { getByText } = render(
         <TestComponent
           confirmOptions={{
-            disableCancelButton: false,
+            hideCancelButton: false,
           }}
         />
       );
@@ -212,11 +212,11 @@ describe("useConfirm", () => {
       expect(cancelButton).toBeTruthy();
     });
 
-    test("does not render cancel button when disableCancelButton is true", () => {
+    test("does not render cancel button when hideCancelButton is true", () => {
       const { getByText, queryByText } = render(
         <TestComponent
           confirmOptions={{
-            disableCancelButton: true,
+            hideCancelButton: true,
           }}
         />
       );


### PR DESCRIPTION
The following options have been added:

-  disableCancelButton

if `disableCancelButton` is `true` then the cancel button is not rendered, case `disabeleCancelButton` is `false` or `undefined` then the cancel button is rendered.