### PR TITLE
feat: 🎸 Allow specifying the order of confirm & cancel buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ representing the user choice (resolved on confirmation and rejected on cancellat
 | **`confirmationKeyword`**               | `string`    | `undefined`       | If provided the confirmation button will be disabled by default and an additional textfield will be rendered. The confirmation button will only be enabled when the contents of the textfield match the value of `confirmationKeyword` |
 | **`confirmationKeywordTextFieldProps`** | `object`    | `{}`              | Material-UI [TextField](https://mui.com/material-ui/api/text-field/) props for the confirmation keyword textfield.                                                                                                                     |
 | **`hideCancelButton`**                  | `boolean`   | `false`           | Whether to hide the cancel button.                                                                                                                                                                                                     |
+| **`buttonOrder`**                  | `string[]`   | `['cancel','confirm']`           | Specify the order of confirm and cancel buttons.                                                                                                                                                                                                     |
 
 
 ## Useful notes

--- a/src/ConfirmProvider.js
+++ b/src/ConfirmProvider.js
@@ -17,6 +17,7 @@ const DEFAULT_OPTIONS = {
   allowClose: true,
   confirmationKeywordTextFieldProps: {},
   hideCancelButton: false,
+  buttonOrder: ['cancel','confirm'],
 };
 
 const buildOptions = (defaultOptions, options) => {

--- a/src/ConfirmationDialog.js
+++ b/src/ConfirmationDialog.js
@@ -57,8 +57,7 @@ const ConfirmationDialog = ({
       return !hideCancelButton && <Button {...cancellationButtonProps} onClick={onCancel}>
         {cancellationText}
       </Button>
-    }
-    if (buttonType === 'confirm') {
+    } else if (buttonType === 'confirm') {
         return (<Button
             color="primary"
             disabled={confirmationButtonDisabled}
@@ -67,6 +66,8 @@ const ConfirmationDialog = ({
           >
             {confirmationText}
           </Button>)
+    } else {
+      throw new Error('Supported button types are only `confirm` and `cancel`')
     }
   });
 

--- a/src/ConfirmationDialog.js
+++ b/src/ConfirmationDialog.js
@@ -30,6 +30,7 @@ const ConfirmationDialog = ({
     confirmationKeyword,
     confirmationKeywordTextFieldProps,
     hideCancelButton,
+    buttonOrder,
   } = options;
 
   const [confirmationKeywordValue, setConfirmationKeywordValue] =
@@ -50,6 +51,28 @@ const ConfirmationDialog = ({
       )}
     </>
   );
+
+  const dialogActions = buttonOrder.map(o => {
+    switch (o) {
+      case 'cancel':
+        if (!hideCancelButton) {
+          return (
+            <Button {...cancellationButtonProps} onClick={onCancel}>
+              {cancellationText}
+            </Button>
+          )
+        }
+      case 'confirm': 
+        return (<Button
+          color="primary"
+          disabled={confirmationButtonDisabled}
+          {...confirmationButtonProps}
+          onClick={onConfirm}
+        >
+          {confirmationText}
+        </Button>)
+    }
+  });
 
   return (
     <Dialog
@@ -75,19 +98,7 @@ const ConfirmationDialog = ({
         )
       )}
       <DialogActions {...dialogActionsProps}>
-        {!hideCancelButton && (
-          <Button {...cancellationButtonProps} onClick={onCancel}>
-            {cancellationText}
-          </Button>
-        )}
-        <Button
-          color="primary"
-          disabled={confirmationButtonDisabled}
-          {...confirmationButtonProps}
-          onClick={onConfirm}
-        >
-          {confirmationText}
-        </Button>
+        {dialogActions}
       </DialogActions>
     </Dialog>
   );

--- a/src/ConfirmationDialog.js
+++ b/src/ConfirmationDialog.js
@@ -52,25 +52,21 @@ const ConfirmationDialog = ({
     </>
   );
 
-  const dialogActions = buttonOrder.map(o => {
-    switch (o) {
-      case 'cancel':
-        if (!hideCancelButton) {
-          return (
-            <Button {...cancellationButtonProps} onClick={onCancel}>
-              {cancellationText}
-            </Button>
-          )
-        }
-      case 'confirm': 
+  const dialogActions = buttonOrder.map(buttonType => {
+    if (buttonType === 'cancel') {
+      return !hideCancelButton && <Button {...cancellationButtonProps} onClick={onCancel}>
+        {cancellationText}
+      </Button>
+    }
+    if (buttonType === 'confirm') {
         return (<Button
-          color="primary"
-          disabled={confirmationButtonDisabled}
-          {...confirmationButtonProps}
-          onClick={onConfirm}
-        >
-          {confirmationText}
-        </Button>)
+            color="primary"
+            disabled={confirmationButtonDisabled}
+            {...confirmationButtonProps}
+            onClick={onConfirm}
+          >
+            {confirmationText}
+          </Button>)
     }
   });
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -22,6 +22,7 @@ export interface ConfirmOptions {
   confirmationKeyword?: string;
   confirmationKeywordTextFieldProps?: TextFieldProps;
   hideCancelButton?: boolean;
+  buttonOrder?: string[];
 }
 
 export interface ConfirmProviderProps {

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -207,6 +207,21 @@ const WithConfirmationKeywordAndCustomTextFieldProps = () => {
   );
 };
 
+const WithReversedButtons = () => {
+  const confirm = useConfirm();
+  return (
+    <Button
+      onClick={() => {
+        confirm({ buttonOrder: ['confirm','cancel'] }).then(
+          confirmationAction
+        );
+      }}
+    >
+      Click
+    </Button>
+  );
+};
+
 storiesOf("Confirmation dialog", module)
   .addDecorator((getStory) => <ConfirmProvider>{getStory()}</ConfirmProvider>)
   .add("basic", () => <Basic />)
@@ -222,4 +237,5 @@ storiesOf("Confirmation dialog", module)
   .add("with confirmation keyword", () => <WithConfirmationKeyword />)
   .add("with confirmation keyword and custom textfield props", () => (
     <WithConfirmationKeywordAndCustomTextFieldProps />
-  ));
+  ))
+  .add("with reversed buttons keyword", () => <WithReversedButtons />);


### PR DESCRIPTION
Address comment 67 and something I'd like to use too :)

https://github.com/jonatanklosko/material-ui-confirm/issues/67

Allows a specification of the order of buttons within Dialog Actions...
Storybook, documentation updated to match and tests all passing.

Thanks for considering this PR :)