### PR TITLE
Allow dialogActions children

### DIFF
--- a/src/ConfirmationDialog.js
+++ b/src/ConfirmationDialog.js
@@ -105,7 +105,10 @@ const ConfirmationDialog = ({
           <DialogContent {...contentProps}>{confirmationContent}</DialogContent>
         )
       )}
-      <DialogActions {...dialogActionsProps}>{dialogActions}</DialogActions>
+      <DialogActions {...dialogActionsProps}>
+        {dialogActionsProps.children}
+        {dialogActions}
+      </DialogActions>
     </Dialog>
   );
 };

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -80,6 +80,21 @@ const WithDialogActionsProps = () => {
   );
 };
 
+const WithDialogActionsChildren = () => {
+  const confirm = useConfirm();
+  return (
+    <Button
+      onClick={() => {
+        confirm({
+          dialogActionsProps: { children: <Button>Extra Button</Button> },
+        }).then(confirmationAction);
+      }}
+    >
+      Click
+    </Button>
+  );
+};
+
 const WithCustomButtonProps = () => {
   const confirm = useConfirm();
   return (
@@ -229,6 +244,9 @@ storiesOf("Confirmation dialog", module)
   .add("with custom text", () => <WithCustomText />)
   .add("with custom dialog props", () => <WithDialogProps />)
   .add("with custom dialog actions props", () => <WithDialogActionsProps />)
+  .add("with custom dialog actions children", () => (
+    <WithDialogActionsChildren />
+  ))
   .add("with custom button props", () => <WithCustomButtonProps />)
   .add("with custom callbacks", () => <WithCustomCallbacks />)
   .add("with custom elements", () => <WithCustomElements />)


### PR DESCRIPTION
`dialogActionsProps.children` gets overwritten by the buttons. This PR makes it so that whatever is passed to the `children` prop gets added before the buttons.