### PR TITLE
Improve handling of missing ConfirmProvider

### DIFF
--- a/src/ConfirmContext.js
+++ b/src/ConfirmContext.js
@@ -1,3 +1,8 @@
 import { createContext } from "react";
 
-export default createContext();
+export default createContext({
+  confirmBase() {
+    throw new Error("Missing ConfirmProvider");
+  },
+  closeOnParentUnmount() {},
+});

--- a/test/useConfirm.test.js
+++ b/test/useConfirm.test.js
@@ -2,10 +2,12 @@ import React, { useState } from "react";
 import {
   render,
   fireEvent,
+  renderHook,
   waitForElementToBeRemoved,
 } from "@testing-library/react";
 
 import { ConfirmProvider, useConfirm } from "../src/index";
+import { ErrorBoundary } from "react-error-boundary";
 
 describe("useConfirm", () => {
   const deleteConfirmed = jest.fn();
@@ -63,12 +65,12 @@ describe("useConfirm", () => {
             cancellationText: "No way",
             confirmationText: "Yessir",
           }}
-        />,
+        />
       );
       fireEvent.click(getByText("Delete"));
       expect(queryByText("Remove this item?")).toBeTruthy();
       expect(
-        queryByText("This will permanently remove the item."),
+        queryByText("This will permanently remove the item.")
       ).toBeTruthy();
       expect(queryByText("No way")).toBeTruthy();
       expect(queryByText("Yessir")).toBeTruthy();
@@ -80,7 +82,7 @@ describe("useConfirm", () => {
           confirmOptions={{
             content: <div>Arbitrary content</div>,
           }}
-        />,
+        />
       );
       fireEvent.click(getByText("Delete"));
       expect(queryByText("Arbitrary content")).toBeTruthy();
@@ -96,7 +98,7 @@ describe("useConfirm", () => {
         }}
       >
         <DeleteButton confirmOptions={{ cancellationText: "Nope" }} />
-      </ConfirmProvider>,
+      </ConfirmProvider>
     );
     fireEvent.click(getByText("Delete"));
     expect(queryByText("Yessir")).toBeTruthy();
@@ -116,7 +118,7 @@ describe("useConfirm", () => {
             confirmationButtonProps: { disabled: true },
           }}
         />
-      </ConfirmProvider>,
+      </ConfirmProvider>
     );
     fireEvent.click(getByText("Delete"));
     const button = getByText("Yes");
@@ -156,13 +158,13 @@ describe("useConfirm", () => {
           confirmOptions={{
             confirmationKeyword: "DELETE",
           }}
-        />,
+        />
       );
 
       fireEvent.click(getByText("Delete"));
 
       const textfield = getAllByText(
-        (content, element) => element.tagName.toLowerCase() === "input",
+        (content, element) => element.tagName.toLowerCase() === "input"
       )[0];
 
       const confirmationButton = getByText("Ok");
@@ -182,13 +184,13 @@ describe("useConfirm", () => {
           confirmOptions={{
             confirmationKeyword: "DELETE",
           }}
-        />,
+        />
       );
 
       fireEvent.click(getByText("Delete"));
 
       let textfield = getAllByText(
-        (content, element) => element.tagName.toLowerCase() === "input",
+        (content, element) => element.tagName.toLowerCase() === "input"
       )[0];
 
       expect(textfield).toBeTruthy();
@@ -199,7 +201,7 @@ describe("useConfirm", () => {
       fireEvent.click(getByText("Delete"));
 
       textfield = getAllByText(
-        (content, element) => element.tagName.toLowerCase() === "input",
+        (content, element) => element.tagName.toLowerCase() === "input"
       )[0];
 
       expect(textfield.value).toEqual("");
@@ -215,7 +217,7 @@ describe("useConfirm", () => {
             placeholder: "Custom placeholder",
           },
         }}
-      />,
+      />
     );
 
     fireEvent.click(getByText("Delete"));
@@ -232,7 +234,7 @@ describe("useConfirm", () => {
           confirmOptions={{
             hideCancelButton: false,
           }}
-        />,
+        />
       );
 
       fireEvent.click(getByText("Delete"));
@@ -248,7 +250,7 @@ describe("useConfirm", () => {
           confirmOptions={{
             hideCancelButton: true,
           }}
-        />,
+        />
       );
 
       fireEvent.click(getByText("Delete"));
@@ -265,7 +267,7 @@ describe("useConfirm", () => {
         confirmOptions={{
           acknowledgement: "I confirm and understand the risk",
         }}
-      />,
+      />
     );
 
     fireEvent.click(getByText("Delete"));
@@ -273,7 +275,7 @@ describe("useConfirm", () => {
     const checkboxLabels = getAllByText(
       (content, element) =>
         element.tagName.toLowerCase() === "span" &&
-        element.classList.contains("MuiFormControlLabel-label"),
+        element.classList.contains("MuiFormControlLabel-label")
     );
 
     expect(checkboxLabels).toBeTruthy();
@@ -290,7 +292,7 @@ describe("useConfirm", () => {
           confirmOptions={{
             acknowledgement: "I confirm and understand the risk",
           }}
-        />,
+        />
       );
 
       for (let i = 0; i <= 1; i++) {
@@ -324,13 +326,13 @@ describe("useConfirm", () => {
               style: { marginTop: "12px" },
             },
           }}
-        />,
+        />
       );
 
       fireEvent.click(getByText("Delete"));
 
       const formLabelElement = getAllByText(
-        (content, element) => element.tagName.toLowerCase() === "label",
+        (content, element) => element.tagName.toLowerCase() === "label"
       )[0];
 
       expect(formLabelElement).toBeTruthy();
@@ -347,7 +349,7 @@ describe("useConfirm", () => {
               style: { marginRight: "15px" },
             },
           }}
-        />,
+        />
       );
 
       fireEvent.click(getByText("Delete"));
@@ -355,7 +357,7 @@ describe("useConfirm", () => {
       const checkboxWrappers = getAllByText(
         (content, element) =>
           element.tagName.toLowerCase() === "span" &&
-          element.classList.contains("MuiCheckbox-root"),
+          element.classList.contains("MuiCheckbox-root")
       );
 
       expect(checkboxWrappers.length).toBe(1);
@@ -417,6 +419,17 @@ describe("useConfirm", () => {
       fireEvent.click(getByText("Ok"));
       await waitForElementToBeRemoved(() => queryByText("Are you sure?"));
       expect(deleteConfirmed).toHaveBeenCalled();
+    });
+  });
+
+  describe("missing ConfirmProvider", () => {
+    test("throws an error when ConfirmProvider is missing", () => {
+      const { result } = renderHook(() => useConfirm());
+      expect(() => result.current()).toThrowError("Missing ConfirmProvider");
+    });
+
+    test("does not throw an error if it's not used", () => {
+      expect(() => render(<DeleteButton />)).not.toThrow();
     });
   });
 });

--- a/test/useConfirm.test.js
+++ b/test/useConfirm.test.js
@@ -7,7 +7,6 @@ import {
 } from "@testing-library/react";
 
 import { ConfirmProvider, useConfirm } from "../src/index";
-import { ErrorBoundary } from "react-error-boundary";
 
 describe("useConfirm", () => {
   const deleteConfirmed = jest.fn();

--- a/test/useConfirm.test.js
+++ b/test/useConfirm.test.js
@@ -64,12 +64,12 @@ describe("useConfirm", () => {
             cancellationText: "No way",
             confirmationText: "Yessir",
           }}
-        />
+        />,
       );
       fireEvent.click(getByText("Delete"));
       expect(queryByText("Remove this item?")).toBeTruthy();
       expect(
-        queryByText("This will permanently remove the item.")
+        queryByText("This will permanently remove the item."),
       ).toBeTruthy();
       expect(queryByText("No way")).toBeTruthy();
       expect(queryByText("Yessir")).toBeTruthy();
@@ -81,7 +81,7 @@ describe("useConfirm", () => {
           confirmOptions={{
             content: <div>Arbitrary content</div>,
           }}
-        />
+        />,
       );
       fireEvent.click(getByText("Delete"));
       expect(queryByText("Arbitrary content")).toBeTruthy();
@@ -97,7 +97,7 @@ describe("useConfirm", () => {
         }}
       >
         <DeleteButton confirmOptions={{ cancellationText: "Nope" }} />
-      </ConfirmProvider>
+      </ConfirmProvider>,
     );
     fireEvent.click(getByText("Delete"));
     expect(queryByText("Yessir")).toBeTruthy();
@@ -117,7 +117,7 @@ describe("useConfirm", () => {
             confirmationButtonProps: { disabled: true },
           }}
         />
-      </ConfirmProvider>
+      </ConfirmProvider>,
     );
     fireEvent.click(getByText("Delete"));
     const button = getByText("Yes");
@@ -157,13 +157,13 @@ describe("useConfirm", () => {
           confirmOptions={{
             confirmationKeyword: "DELETE",
           }}
-        />
+        />,
       );
 
       fireEvent.click(getByText("Delete"));
 
       const textfield = getAllByText(
-        (content, element) => element.tagName.toLowerCase() === "input"
+        (content, element) => element.tagName.toLowerCase() === "input",
       )[0];
 
       const confirmationButton = getByText("Ok");
@@ -183,13 +183,13 @@ describe("useConfirm", () => {
           confirmOptions={{
             confirmationKeyword: "DELETE",
           }}
-        />
+        />,
       );
 
       fireEvent.click(getByText("Delete"));
 
       let textfield = getAllByText(
-        (content, element) => element.tagName.toLowerCase() === "input"
+        (content, element) => element.tagName.toLowerCase() === "input",
       )[0];
 
       expect(textfield).toBeTruthy();
@@ -200,7 +200,7 @@ describe("useConfirm", () => {
       fireEvent.click(getByText("Delete"));
 
       textfield = getAllByText(
-        (content, element) => element.tagName.toLowerCase() === "input"
+        (content, element) => element.tagName.toLowerCase() === "input",
       )[0];
 
       expect(textfield.value).toEqual("");
@@ -216,7 +216,7 @@ describe("useConfirm", () => {
             placeholder: "Custom placeholder",
           },
         }}
-      />
+      />,
     );
 
     fireEvent.click(getByText("Delete"));
@@ -233,7 +233,7 @@ describe("useConfirm", () => {
           confirmOptions={{
             hideCancelButton: false,
           }}
-        />
+        />,
       );
 
       fireEvent.click(getByText("Delete"));
@@ -249,7 +249,7 @@ describe("useConfirm", () => {
           confirmOptions={{
             hideCancelButton: true,
           }}
-        />
+        />,
       );
 
       fireEvent.click(getByText("Delete"));
@@ -266,7 +266,7 @@ describe("useConfirm", () => {
         confirmOptions={{
           acknowledgement: "I confirm and understand the risk",
         }}
-      />
+      />,
     );
 
     fireEvent.click(getByText("Delete"));
@@ -274,7 +274,7 @@ describe("useConfirm", () => {
     const checkboxLabels = getAllByText(
       (content, element) =>
         element.tagName.toLowerCase() === "span" &&
-        element.classList.contains("MuiFormControlLabel-label")
+        element.classList.contains("MuiFormControlLabel-label"),
     );
 
     expect(checkboxLabels).toBeTruthy();
@@ -291,7 +291,7 @@ describe("useConfirm", () => {
           confirmOptions={{
             acknowledgement: "I confirm and understand the risk",
           }}
-        />
+        />,
       );
 
       for (let i = 0; i <= 1; i++) {
@@ -325,13 +325,13 @@ describe("useConfirm", () => {
               style: { marginTop: "12px" },
             },
           }}
-        />
+        />,
       );
 
       fireEvent.click(getByText("Delete"));
 
       const formLabelElement = getAllByText(
-        (content, element) => element.tagName.toLowerCase() === "label"
+        (content, element) => element.tagName.toLowerCase() === "label",
       )[0];
 
       expect(formLabelElement).toBeTruthy();
@@ -348,7 +348,7 @@ describe("useConfirm", () => {
               style: { marginRight: "15px" },
             },
           }}
-        />
+        />,
       );
 
       fireEvent.click(getByText("Delete"));
@@ -356,7 +356,7 @@ describe("useConfirm", () => {
       const checkboxWrappers = getAllByText(
         (content, element) =>
           element.tagName.toLowerCase() === "span" &&
-          element.classList.contains("MuiCheckbox-root")
+          element.classList.contains("MuiCheckbox-root"),
       );
 
       expect(checkboxWrappers.length).toBe(1);


### PR DESCRIPTION
Prior to 3.0.13, material-ui-confirm allowed usage without a `ConfirmProvider`, as long as it wasn't invoked.  This was useful for test purposes; automated tests of components that happened to call `useConfirm` could skip rendering `ConfirmProvider` as long as they didn't actually depend on showing a confirmation prompt.

Starting with 3.0.13, code instead throws errors similar to the following:

```
    Missing ConfirmProvider

      55 |       await Promise.race([
      56 |         exited,
    > 57 |         confirm(useOptions)
         |         ^
      58 |           .then(() => (confirmed = true))
      59 |           .catch(() => (confirmed = false)),
      60 |       ]);

      at confirmBase (../../node_modules/material-ui-confirm/dist/material-ui-confirm.cjs.js:144:11)
      at ../../node_modules/material-ui-confirm/dist/material-ui-confirm.cjs.js:350:12
```

This PR adds a default `ConfirmProvider` context that does nothing if confirmation prompts are not shown and throws a clear error message if a confirmation prompt is attempted.

(I realize that rendering tests without a `ConfirmProvider` is not exactly normal usage - I think it's worth supporting, but if you'd prefer to not go in this direction, I understand.)