### PR TITLE
Add should close on parent unmount config flag

### DIFF
--- a/src/ConfirmProvider.js
+++ b/src/ConfirmProvider.js
@@ -21,6 +21,7 @@ const DEFAULT_OPTIONS = {
   acknowledgement: false,
   acknowledgementFormControlLabelProps: {},
   acknowledgementCheckboxProps: {},
+  closeOnParentUnmount: true,
 };
 
 const buildOptions = (defaultOptions, options) => {
@@ -66,6 +67,12 @@ const buildOptions = (defaultOptions, options) => {
       DEFAULT_OPTIONS.acknowledgementCheckboxProps),
     ...(options.acknowledgementCheckboxProps || {}),
   };
+  // We must accept 'false' values, if present.
+  const closeOnParentUnmount = typeof options.closeOnParentUnmount !== 'undefined' ?
+    options.closeOnParentUnmount :
+    typeof defaultOptions.closeOnParentUnmount !== 'undefined' ?
+      defaultOptions.closeOnParentUnmount :
+      DEFAULT_OPTIONS.closeOnParentUnmount;
 
   return {
     ...DEFAULT_OPTIONS,
@@ -80,6 +87,7 @@ const buildOptions = (defaultOptions, options) => {
     confirmationKeywordTextFieldProps,
     acknowledgementFormControlLabelProps,
     acknowledgementCheckboxProps,
+    closeOnParentUnmount,
   };
 };
 
@@ -94,6 +102,8 @@ const ConfirmProvider = ({ children, defaultOptions = {} }) => {
   const [options, setOptions] = useState({});
   const [key, setKey] = useState(0);
 
+  const dialogOptions = buildOptions(defaultOptions, options ?? {});
+
   const confirmBase = useCallback((parentId, options = {}) => {
     return new Promise((resolve, reject) => {
       setKey((key) => key + 1);
@@ -104,7 +114,7 @@ const ConfirmProvider = ({ children, defaultOptions = {} }) => {
 
   const closeOnParentUnmount = useCallback((parentId) => {
     setState((state) => {
-      if (state && state.parentId === parentId) {
+      if (dialogOptions.closeOnParentUnmount && state && state.parentId === parentId) {
         return null;
       } else {
         return state;
@@ -142,7 +152,7 @@ const ConfirmProvider = ({ children, defaultOptions = {} }) => {
       <ConfirmationDialog
         key={key}
         open={state !== null}
-        options={buildOptions(defaultOptions, options ?? {})}
+        options={dialogOptions}
         onClose={handleClose}
         onCancel={handleCancel}
         onConfirm={handleConfirm}

--- a/src/useConfirm.js
+++ b/src/useConfirm.js
@@ -11,7 +11,7 @@ const useConfirmId = () => {
   return `confirm-${id}`;
 };
 
-const useConfirm = (shouldCloseOnParentUnmount = true) => {
+const useConfirm = () => {
   const parentId = useConfirmId();
   const { confirmBase, closeOnParentUnmount } = useContext(ConfirmContext);
 
@@ -22,17 +22,15 @@ const useConfirm = (shouldCloseOnParentUnmount = true) => {
     [parentId],
   );
 
-  if (shouldCloseOnParentUnmount) {
-    // When the component calling useConfirm is unmounted, we automatically
-    // close the associated confirmation dialog. Note that we use a
-    // unique id per each useConfirm usage, so that we don't close the
-    // dialog when an unrelated component unmounts
-    useEffect(() => {
-      return () => {
-        closeOnParentUnmount(parentId);
-      };
-    }, [parentId]);
-  }
+  // When the component calling useConfirm is unmounted, we automatically
+  // close the associated confirmation dialog. Note that we use a
+  // unique id per each useConfirm usage, so that we don't close the
+  // dialog when an unrelated component unmounts
+  useEffect(() => {
+    return () => {
+      closeOnParentUnmount(parentId);
+    };
+  }, [parentId]);
 
   return confirm;
 };

--- a/src/useConfirm.js
+++ b/src/useConfirm.js
@@ -11,7 +11,7 @@ const useConfirmId = () => {
   return `confirm-${id}`;
 };
 
-const useConfirm = () => {
+const useConfirm = (shouldCloseOnParentUnmount = true) => {
   const parentId = useConfirmId();
   const { confirmBase, closeOnParentUnmount } = useContext(ConfirmContext);
 
@@ -22,15 +22,17 @@ const useConfirm = () => {
     [parentId],
   );
 
-  // When the component calling useConfirm is unmounted, we automatically
-  // close the associated confirmation dialog. Note that we use a
-  // unique id per each useConfirm usage, so that we don't close the
-  // dialog when an unrelated component unmounts
-  useEffect(() => {
-    return () => {
-      closeOnParentUnmount(parentId);
-    };
-  }, [parentId]);
+  if (shouldCloseOnParentUnmount) {
+    // When the component calling useConfirm is unmounted, we automatically
+    // close the associated confirmation dialog. Note that we use a
+    // unique id per each useConfirm usage, so that we don't close the
+    // dialog when an unrelated component unmounts
+    useEffect(() => {
+      return () => {
+        closeOnParentUnmount(parentId);
+      };
+    }, [parentId]);
+  }
 
   return confirm;
 };

--- a/test/useConfirm.test.js
+++ b/test/useConfirm.test.js
@@ -26,30 +26,10 @@ describe("useConfirm", () => {
     );
   };
 
-  const DeleteButtonWithoutAutoDismiss = ({ confirmOptions, text = "Delete" }) => {
-    const confirm = useConfirm(false);
-
-    return (
-      <button
-        onClick={() =>
-          confirm(confirmOptions).then(deleteConfirmed).catch(deleteCancelled)
-        }
-      >
-        {text}
-      </button>
-    );
-  };
-
   const TestComponent = ({ confirmOptions }) => (
     <ConfirmProvider>
       <DeleteButton confirmOptions={confirmOptions} />
     </ConfirmProvider>
-  );
-
-  const TestComponentWithoutAutoDismiss = ({ confirmOptions }) => (
-      <ConfirmProvider>
-        <DeleteButtonWithoutAutoDismiss confirmOptions={confirmOptions} />
-      </ConfirmProvider>
   );
 
   test("resolves the promise on confirm", async () => {
@@ -428,7 +408,7 @@ describe("useConfirm", () => {
       expect(deleteCancelled).not.toHaveBeenCalled();
     });
 
-    test("does not close the modal when another component with useConfirm is unmounted and shouldCloseOnParentUnmount is true", async () => {
+    test("does not close the modal when another component with useConfirm is unmounted and closeOnParentUnmount is true", async () => {
       const ParentComponent = ({}) => {
         const [alive, setAlive] = useState(true);
 
@@ -455,14 +435,14 @@ describe("useConfirm", () => {
     });
   });
 
-  test("does not close the modal when another component with useConfirm is unmounted and shouldCloseOnParentUnmount is false", async () => {
+  test("does not close the modal when another component with useConfirm is unmounted and closeOnParentUnmount is false", async () => {
     const ParentComponent = ({}) => {
       const [alive, setAlive] = useState(true);
 
       return (
         <ConfirmProvider>
-          {alive && <DeleteButtonWithoutAutoDismiss confirmOptions={{}} text="Delete 1" />}
-          <DeleteButtonWithoutAutoDismiss confirmOptions={{}} text="Delete 2" />
+          {alive && <DeleteButton confirmOptions={{ closeOnParentUnmount: false }} text="Delete 1" />}
+          <DeleteButton confirmOptions={{ closeOnParentUnmount: false }} text="Delete 2" />
           <button onClick={() => setAlive(false)}>Unmount child</button>
         </ConfirmProvider>
       );


### PR DESCRIPTION
Why would I prefer to close the confirmation dialog when the calling component has decided to disappear?
Just let devs decide it!
Expecially because this behaviour change can break some existing products, if they rely on npm's version management for dependencies (like if they jump from version **3.0.12** to **3.0.16**, since they might have **^3.0.4** in their **package.json** for this library).