### PR TITLE
Fix CJS build

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -5,7 +5,7 @@ import copy from "rollup-plugin-copy";
 export default {
   input: "src/index.js",
   output: [
-    { file: pkg.main, format: "cjs" },
+    { file: pkg.main, format: "cjs", interop: "compat" },
     { file: pkg.module, format: "esm" },
   ],
   external: ["react", /^@mui\/material*/],


### PR DESCRIPTION
This is necessary to resolve MUI default exports from a CJS environment after the upgrade from Rollup 2 ro 4. See [Rollup version 3's release notes](https://github.com/rollup/rollup/releases/tag/v3.0.0#:~:text=Change%20the%20default%20for%20output.interop,be%20a%20property%20(%234611)) and [the docs for Rollup's interop option](https://rollupjs.org/configuration-options/#output-interop).

Fixes #121