### PR TITLE
Always resolve the promise with confirmation status and close reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,17 @@ import { useConfirm } from "material-ui-confirm";
 const Item = () => {
   const confirm = useConfirm();
 
-  const handleClick = () => {
-    confirm({ description: "This action is permanent!" })
-      .then(() => {
-        /* ... */
-      })
-      .catch(() => {
-        /* ... */
-      });
+  const handleClick = async () => {
+    const { confirmed, reason } = await confirm({
+      description: "This action is permanent!",
+    });
+
+    if (confirmed) {
+      /* ... */
+    }
+
+    console.log(reason);
+    //=> "confirm" | "cancel" | "natural" | "unmount"
   };
 
   return <Button onClick={handleClick}>Click</Button>;
@@ -66,42 +69,43 @@ This component is required in order to render a dialog in the component tree.
 
 ##### Props
 
-| Name                 | Type     | Default | Description                                                             |
-| -------------------- | -------- | ------- | ----------------------------------------------------------------------- |
-| **`defaultOptions`** | `object` | `{}`    | Overrides the default options used by [`confirm`](#useconfirm-confirm). |
+| Name                  | Type      | Default | Description                                                                                                                                                       |
+| --------------------- | --------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`defaultOptions`**  | `object`  | `{}`    | Overrides the default options used by [`confirm`](#useconfirm-confirm).                                                                                           |
+| **`useLegacyReturn`** | `boolean` | `false` | When set to `true`, restores the `confirm` behaviour from v3: the returned promise is resolved on confirm, rejected on cancel, and kept pending on natural close. |
 
 #### `useConfirm() => confirm`
 
 This hook returns the `confirm` function.
 
-#### `confirm([options]) => Promise`
+#### `confirm([options]) => Promise<{ confirmed: boolean; reason: "confirm" | "cancel" | "natural" | "unmount"; }>`
 
 This function opens a confirmation dialog and returns a promise
 representing the user choice (resolved on confirmation and rejected on cancellation).
 
 ##### Options
 
-| Name                                    | Type        | Default                 | Description                                                                                                                                                                                                                            |
-| --------------------------------------- | ----------- | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`title`**                             | `ReactNode` | `'Are you sure?'`       | Dialog title.                                                                                                                                                                                                                          |
-| **`description`**                       | `ReactNode` | `''`                    | Dialog content, automatically wrapped in `DialogContentText`.                                                                                                                                                                          |
-| **`content`**                           | `ReactNode` | `null`                  | Dialog content, same as `description` but not wrapped in `DialogContentText`. Supersedes `description` if present.                                                                                                                     |
-| **`confirmationText`**                  | `ReactNode` | `'Ok'`                  | Confirmation button caption.                                                                                                                                                                                                           |
-| **`cancellationText`**                  | `ReactNode` | `'Cancel'`              | Cancellation button caption.                                                                                                                                                                                                           |
-| **`dialogProps`**                       | `object`    | `{}`                    | Material-UI [Dialog](https://mui.com/material-ui/api/dialog/#props) props.                                                                                                                                                             |
-| **`dialogActionsProps`**                | `object`    | `{}`                    | Material-UI [DialogActions](https://mui.com/material-ui/api/dialog-actions/#props) props.                                                                                                                                              |
-| **`confirmationButtonProps`**           | `object`    | `{}`                    | Material-UI [Button](https://mui.com/material-ui/api/button/#props) props for the confirmation button.                                                                                                                                 |
-| **`cancellationButtonProps`**           | `object`    | `{}`                    | Material-UI [Button](https://mui.com/material-ui/api/dialog/#props) props for the cancellation button.                                                                                                                                 |
-| **`titleProps`**                        | `object`    | `{}`                    | Material-UI [DialogTitle](https://mui.com/api/dialog-title/#props) props for the dialog title.                                                                                                                                         |
-| **`contentProps`**                      | `object`    | `{}`                    | Material-UI [DialogContent](https://mui.com/api/dialog-content/#props) props for the dialog content.                                                                                                                                   |
-| **`allowClose`**                        | `boolean`   | `true`                  | Whether natural close (escape or backdrop click) should close the dialog. When set to `false` force the user to either cancel or confirm explicitly.                                                                                   |
-| **`confirmationKeyword`**               | `string`    | `undefined`             | If provided the confirmation button will be disabled by default and an additional textfield will be rendered. The confirmation button will only be enabled when the contents of the textfield match the value of `confirmationKeyword` |
-| **`confirmationKeywordTextFieldProps`** | `object`    | `{}`                    | Material-UI [TextField](https://mui.com/material-ui/api/text-field/) props for the confirmation keyword textfield.                                                                                                                     |
-| **`acknowledgement`**               | `string`    | `undefined`             | If provided shows the acknowledge checkbox with this string as checkbox label and disables the confirm button while the checkbox is unchecked.  |
-| **`acknowledgementFormControlLabelProps`** | `object`    | `{}`                    | Material-UI [FormControlLabel](https://mui.com/material-ui/api/form-control-label/#props) props for the form control label.                                                                                                                     |
-| **`acknowledgementCheckboxProps`** | `object`    | `{}`                    | Material-UI [Checkbox](https://mui.com/material-ui/api/checkbox/#props) props for the acknowledge checkbox.                                                                                                                     |
-| **`hideCancelButton`**                  | `boolean`   | `false`                 | Whether to hide the cancel button.                                                                                                                                                                                                     |
-| **`buttonOrder`**                       | `string[]`  | `["cancel", "confirm"]` | Specify the order of confirm and cancel buttons.                                                                                                                                                                                       |
+| Name                                       | Type        | Default                 | Description                                                                                                                                                                                                                            |
+| ------------------------------------------ | ----------- | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`title`**                                | `ReactNode` | `'Are you sure?'`       | Dialog title.                                                                                                                                                                                                                          |
+| **`description`**                          | `ReactNode` | `''`                    | Dialog content, automatically wrapped in `DialogContentText`.                                                                                                                                                                          |
+| **`content`**                              | `ReactNode` | `null`                  | Dialog content, same as `description` but not wrapped in `DialogContentText`. Supersedes `description` if present.                                                                                                                     |
+| **`confirmationText`**                     | `ReactNode` | `'Ok'`                  | Confirmation button caption.                                                                                                                                                                                                           |
+| **`cancellationText`**                     | `ReactNode` | `'Cancel'`              | Cancellation button caption.                                                                                                                                                                                                           |
+| **`dialogProps`**                          | `object`    | `{}`                    | Material-UI [Dialog](https://mui.com/material-ui/api/dialog/#props) props.                                                                                                                                                             |
+| **`dialogActionsProps`**                   | `object`    | `{}`                    | Material-UI [DialogActions](https://mui.com/material-ui/api/dialog-actions/#props) props.                                                                                                                                              |
+| **`confirmationButtonProps`**              | `object`    | `{}`                    | Material-UI [Button](https://mui.com/material-ui/api/button/#props) props for the confirmation button.                                                                                                                                 |
+| **`cancellationButtonProps`**              | `object`    | `{}`                    | Material-UI [Button](https://mui.com/material-ui/api/dialog/#props) props for the cancellation button.                                                                                                                                 |
+| **`titleProps`**                           | `object`    | `{}`                    | Material-UI [DialogTitle](https://mui.com/api/dialog-title/#props) props for the dialog title.                                                                                                                                         |
+| **`contentProps`**                         | `object`    | `{}`                    | Material-UI [DialogContent](https://mui.com/api/dialog-content/#props) props for the dialog content.                                                                                                                                   |
+| **`allowClose`**                           | `boolean`   | `true`                  | Whether natural close (escape or backdrop click) should close the dialog. When set to `false` force the user to either cancel or confirm explicitly.                                                                                   |
+| **`confirmationKeyword`**                  | `string`    | `undefined`             | If provided the confirmation button will be disabled by default and an additional textfield will be rendered. The confirmation button will only be enabled when the contents of the textfield match the value of `confirmationKeyword` |
+| **`confirmationKeywordTextFieldProps`**    | `object`    | `{}`                    | Material-UI [TextField](https://mui.com/material-ui/api/text-field/) props for the confirmation keyword textfield.                                                                                                                     |
+| **`acknowledgement`**                      | `string`    | `undefined`             | If provided shows the acknowledge checkbox with this string as checkbox label and disables the confirm button while the checkbox is unchecked.                                                                                         |
+| **`acknowledgementFormControlLabelProps`** | `object`    | `{}`                    | Material-UI [FormControlLabel](https://mui.com/material-ui/api/form-control-label/#props) props for the form control label.                                                                                                            |
+| **`acknowledgementCheckboxProps`**         | `object`    | `{}`                    | Material-UI [Checkbox](https://mui.com/material-ui/api/checkbox/#props) props for the acknowledge checkbox.                                                                                                                            |
+| **`hideCancelButton`**                     | `boolean`   | `false`                 | Whether to hide the cancel button.                                                                                                                                                                                                     |
+| **`buttonOrder`**                          | `string[]`  | `["cancel", "confirm"]` | Specify the order of confirm and cancel buttons.                                                                                                                                                                                       |
 
 ## Useful notes
 
@@ -117,14 +121,14 @@ naturally triggers a click.
 const MyComponent = () => {
   // ...
 
-  const handleClick = () => {
-    confirm({ confirmationButtonProps: { autoFocus: true } })
-      .then(() => {
-        /* ... */
-      })
-      .catch(() => {
-        /* ... */
-      });
+  const handleClick = async () => {
+    const { confirmed } = await confirm({
+      confirmationButtonProps: { autoFocus: true },
+    });
+
+    if (confirmed) {
+      /* ... */
+    }
   };
 
   // ...

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -32,9 +32,17 @@ export interface ConfirmOptions {
 export interface ConfirmProviderProps {
   children: React.ReactNode;
   defaultOptions?: ConfirmOptions;
+  useLegacyReturn?: boolean;
+}
+
+export interface ConfirmResult {
+  confirmed: boolean;
+  reason: "confirm" | "cancel" | "natural" | "unmount";
 }
 
 export const ConfirmProvider: React.ComponentType<ConfirmProviderProps>;
 
-export const useConfirm: () => (options?: ConfirmOptions) => Promise<void>;
-export const confirm: (options?: ConfirmOptions) => Promise<void>;
+export const useConfirm: () => (
+  options?: ConfirmOptions,
+) => Promise<ConfirmResult>;
+export const confirm: (options?: ConfirmOptions) => Promise<ConfirmResult>;

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -7,15 +7,14 @@ import Tooltip from "@mui/material/Tooltip";
 import { ConfirmProvider, useConfirm } from "../src/index";
 import { confirm as staticConfirm } from "../src/index";
 
-const confirmationAction = action("confirmed");
-const cancellationAction = action("cancelled");
+const closeAction = action("closed");
 
 const ConfirmationDialog = (options) => {
   const confirm = useConfirm();
   return (
     <Button
       onClick={() => {
-        confirm(options).then(confirmationAction).catch(cancellationAction);
+        confirm(options).then(closeAction);
       }}
     >
       Click
@@ -36,9 +35,7 @@ export const Basic = {
 export const StaticMethod = {
   render: () => {
     return (
-      <Button onClick={() => staticConfirm().then(confirmationAction)}>
-        Click
-      </Button>
+      <Button onClick={() => staticConfirm().then(closeAction)}>Click</Button>
     );
   },
 };
@@ -73,28 +70,6 @@ export const WithCustomButtonProps = {
     confirmationButtonProps: { color: "secondary", variant: "outlined" },
     cancellationButtonProps: { variant: "outlined" },
   },
-};
-
-// You can't just inline this into the render proeprty, it needs to be a JSX
-// component to pick up the context
-function CustomCallbacksComponent() {
-  const confirm = useConfirm();
-  return (
-    <Button
-      onClick={() => {
-        confirm()
-          .then(confirmationAction)
-          .catch(cancellationAction)
-          .finally(action("closed"));
-      }}
-    >
-      Click
-    </Button>
-  );
-}
-
-export const WithCustomCallbacks = {
-  render: () => <CustomCallbacksComponent />,
 };
 
 export const WithCustomElements = {


### PR DESCRIPTION
This has been requested multiple times, directly or indirectly (#41, #78, #104). I wanted to avoid a breaking change, but it is what it is. With this PR the `confirm` function always resolves when the modal disappears, and the result is:

```ts
{
  confirmed: true | false;
  reason: "confirm" | "cancel" | "natural" | "unmount";
}
```

My rationale for finally making this change is that, in terms of functionality, it is a superset of the current API, which gives the user more control.

I am going to release v4 with this change. The old behaviour can still be enabled by adding one attribute to the provider:

```jsx
<ConfirmProvider useLegacyReturn>
  {/* ... */}
</ConfirmProvider>
```