### PR TITLE
Feature/add flag for enforcing natural close behavior

### DIFF
--- a/src/ConfirmProvider.js
+++ b/src/ConfirmProvider.js
@@ -21,6 +21,7 @@ const DEFAULT_OPTIONS = {
   acknowledgement: false,
   acknowledgementFormControlLabelProps: {},
   acknowledgementCheckboxProps: {},
+  enforceNaturalClose: false,
 };
 
 const buildOptions = (defaultOptions, options) => {
@@ -113,8 +114,11 @@ const ConfirmProvider = ({ children, defaultOptions = {} }) => {
   }, []);
 
   const handleClose = useCallback(() => {
-    setState(null);
-  }, []);
+    setState((state) => {
+      options.enforceNaturalClose && state && state.reject();
+      return null;
+    });
+  }, [options]);
 
   const handleCancel = useCallback(() => {
     setState((state) => {

--- a/test/useConfirm.test.js
+++ b/test/useConfirm.test.js
@@ -5,6 +5,7 @@ import {
   renderHook,
   waitForElementToBeRemoved,
 } from "@testing-library/react";
+import userEvent from '@testing-library/user-event';
 
 import { ConfirmProvider, useConfirm } from "../src/index";
 
@@ -52,6 +53,19 @@ describe("useConfirm", () => {
     await waitForElementToBeRemoved(() => queryByText("Are you sure?"));
     expect(deleteConfirmed).not.toHaveBeenCalled();
     expect(deleteCancelled).toHaveBeenCalled();
+  });
+
+  test("does not reject the promise on escape key press (natural cancel)", async () => {
+    const foo = render(<TestComponent />);
+    const { getByText, queryByText } = foo
+    expect(queryByText("Are you sure?")).toBeFalsy();
+    fireEvent.click(getByText("Delete"));
+    const inputNode = queryByText("Are you sure?")
+    expect(inputNode).toBeTruthy();
+    await userEvent.keyboard('{Escape}');
+    await waitForElementToBeRemoved(() => queryByText("Are you sure?"));
+    expect(deleteConfirmed).not.toHaveBeenCalled();
+    expect(deleteCancelled).not.toHaveBeenCalled();
   });
 
   describe("options", () => {

--- a/test/useConfirm.test.js
+++ b/test/useConfirm.test.js
@@ -56,12 +56,10 @@ describe("useConfirm", () => {
   });
 
   test("does not reject the promise on escape key press (natural cancel)", async () => {
-    const foo = render(<TestComponent />);
-    const { getByText, queryByText } = foo
+    const { getByText, queryByText } = render(<TestComponent />);
     expect(queryByText("Are you sure?")).toBeFalsy();
     fireEvent.click(getByText("Delete"));
-    const inputNode = queryByText("Are you sure?")
-    expect(inputNode).toBeTruthy();
+    expect(queryByText("Are you sure?")).toBeTruthy();
     await userEvent.keyboard('{Escape}');
     await waitForElementToBeRemoved(() => queryByText("Are you sure?"));
     expect(deleteConfirmed).not.toHaveBeenCalled();
@@ -69,6 +67,16 @@ describe("useConfirm", () => {
   });
 
   describe("options", () => {
+    test("rejects the promise on escape key (natural cancel) when option provided.", async () => {
+      const { getByText, queryByText } = render(<TestComponent confirmOptions={{enforceNaturalClose: true}} />);
+      expect(queryByText("Are you sure?")).toBeFalsy();
+      fireEvent.click(getByText("Delete"));
+      expect(queryByText("Are you sure?")).toBeTruthy();
+      await userEvent.keyboard('{Escape}');
+      await waitForElementToBeRemoved(() => queryByText("Are you sure?"));
+      expect(deleteConfirmed).not.toHaveBeenCalled();
+      expect(deleteCancelled).toHaveBeenCalled();
+    });
     test("accepts custom text", () => {
       const { getByText, queryByText } = render(
         <TestComponent


### PR DESCRIPTION
Great library, 
I was going to make my own dialog implementation but this well done with the testing and story books.

This change involves adding a feature adds a flag to allow the confirm() promise to be rejected when:
1. escape key is pressed
2. you click outside of the dialog to dismiss.

I named the flag `enforceNaturalClose`, open to ideas for a better naming convention.
Happy to make any changes.
Hope you find this a helpful pr. 🎉

Should I add a storybook test? 
The feature does not seem visually noticeable. 

TODO: 
1. update readme with details 
2. update types as needed `enforceNaturalClose: boolean`